### PR TITLE
Support custom scheme for QR codes

### DIFF
--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -41937,13 +41937,13 @@ exports.createUpdate = createUpdate;
 /**
  * Create a QR code link for an EAS Update.
  */
-function getUpdateGroupQr({ projectId, updateGroupId, appSlug, qrTarget, }) {
+function getUpdateGroupQr({ projectId, updateGroupId, appSlug, scheme, qrTarget, }) {
     const url = new url_1.URL('https://qr.expo.dev/eas-update');
     if (qrTarget === 'dev-build') {
         // While the parameter is called `appScheme`, it's actually the app's slug
         // This should only be added when using dev clients as target
         // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-        url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+        url.searchParams.append('appScheme', scheme || appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
     }
     url.searchParams.append('projectId', projectId);
     url.searchParams.append('groupId', updateGroupId);
@@ -44528,6 +44528,7 @@ function collectContinuousDeployFingerprintInput() {
     return {
         profile: (0, core_1.getInput)('profile'),
         branch: (0, core_1.getInput)('branch'),
+        scheme: (0, core_1.getInput)('scheme'),
         githubToken: (0, core_1.getInput)('github-token'),
         workingDirectory: (0, core_1.getInput)('working-directory'),
     };
@@ -44708,7 +44709,9 @@ function createSummaryForUpdatesAndBuilds({ config, projectId, updates, builds, 
     const iosUpdate = updates.find(update => update.platform === 'ios');
     const getBuildLink = (build) => build ? `[Build Permalink](${(0, expo_1.getBuildLogsUrl)(build)})` : 'n/a';
     const getUpdateLink = (update) => update ? `[Update Permalink](${(0, eas_1.getUpdateGroupWebsite)({ projectId, updateGroupId: update.group })})` : 'n/a';
-    const getUpdateQRURL = (update) => update ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: update.group, appSlug, qrTarget }) : null;
+    const getUpdateQRURL = (update) => update
+        ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: update.group, appSlug, scheme: options.scheme, qrTarget })
+        : null;
     const getBuildDetails = (build) => build
         ? getBuildLink(build) +
             '<br />' +

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -42145,13 +42145,13 @@ exports.createUpdate = createUpdate;
 /**
  * Create a QR code link for an EAS Update.
  */
-function getUpdateGroupQr({ projectId, updateGroupId, appSlug, qrTarget, }) {
+function getUpdateGroupQr({ projectId, updateGroupId, appSlug, scheme, qrTarget, }) {
     const url = new url_1.URL('https://qr.expo.dev/eas-update');
     if (qrTarget === 'dev-build') {
         // While the parameter is called `appScheme`, it's actually the app's slug
         // This should only be added when using dev clients as target
         // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-        url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+        url.searchParams.append('appScheme', scheme || appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
     }
     url.searchParams.append('projectId', projectId);
     url.searchParams.append('groupId', updateGroupId);

--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -15,6 +15,8 @@ inputs:
   branch:
     description: The EAS Update branch on which to publish.
     required: true
+  scheme:
+    description: An optional scheme to use to when generating QR codes.
   github-token:
     description: GitHub token to use when commenting on PR
     required: false

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -14,6 +14,7 @@ export function collectContinuousDeployFingerprintInput() {
   return {
     profile: getInput('profile'),
     branch: getInput('branch'),
+    scheme: getInput('scheme'),
     githubToken: getInput('github-token'),
     workingDirectory: getInput('working-directory'),
   };
@@ -254,7 +255,7 @@ function createSummaryForUpdatesAndBuilds({
   projectId: string;
   updates: EasUpdate[];
   builds: BuildInfo[];
-  options: { qrTarget?: 'expo-go' | 'dev-build' | 'dev-client'; workingDirectory: string };
+  options: { qrTarget?: 'expo-go' | 'dev-build' | 'dev-client'; scheme?: string; workingDirectory: string };
 }) {
   const appSlug = config.slug;
   const qrTarget = getQrTarget(options);
@@ -271,7 +272,9 @@ function createSummaryForUpdatesAndBuilds({
   const getUpdateLink = (update: EasUpdate | undefined) =>
     update ? `[Update Permalink](${getUpdateGroupWebsite({ projectId, updateGroupId: update.group })})` : 'n/a';
   const getUpdateQRURL = (update: EasUpdate | undefined) =>
-    update ? getUpdateGroupQr({ projectId, updateGroupId: update.group, appSlug, qrTarget }) : null;
+    update
+      ? getUpdateGroupQr({ projectId, updateGroupId: update.group, appSlug, scheme: options.scheme, qrTarget })
+      : null;
   const getBuildDetails = (build: BuildInfo | undefined) =>
     build
       ? getBuildLink(build) +

--- a/src/eas.ts
+++ b/src/eas.ts
@@ -72,11 +72,15 @@ export function getUpdateGroupQr({
   projectId,
   updateGroupId,
   appSlug,
+  scheme,
   qrTarget,
 }: {
   projectId: string;
   updateGroupId: string;
   appSlug: string;
+  // Allow overriding the scheme so people with different app bundles can direct
+  // QR codes into the right bundle for the given build.
+  scheme?: string;
   qrTarget: 'expo-go' | 'dev-build';
 }): string {
   const url = new URL('https://qr.expo.dev/eas-update');
@@ -85,7 +89,7 @@ export function getUpdateGroupQr({
     // While the parameter is called `appScheme`, it's actually the app's slug
     // This should only be added when using dev clients as target
     // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-    url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+    url.searchParams.append('appScheme', scheme || appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
   }
 
   url.searchParams.append('projectId', projectId);


### PR DESCRIPTION
If people have many variants of the same app (say a development build, an rc build, and production) then the default scheme that Expo adds to each app for handling QR previews will be the same:

`exp+<slug>://`

This means whichever app was installed last is the one that will be loaded by QR previews, which often isn't what you want. This commit adds support for providing a custom `scheme` to the continuous delivery action that modifies the slug used in the QR code so users can have them open in the correct app.

### Linked issue
Provide the issue(s) which this pull request relates to or fixes.

### Additional context
Are there things the maintainers should be aware of before merging or closing this pull request?
